### PR TITLE
Fix disabling of `DEBUG` and `ADMIN_EXEMPT`

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -26,12 +26,12 @@ class TelegramMonitorBot:
     def __init__(self):
         self.debug = (
             (os.environ.get('DEBUG') is not None) and
-            (os.environ.get('DEBUG').upper() != "false"))
+            (os.environ.get('DEBUG').lower() != "false"))
 
         # Are admins exempt from having messages checked?
         self.admin_exempt = (
             (os.environ.get('ADMIN_EXEMPT') is not None) and
-            (os.environ.get('ADMIN_EXEMPT').upper() != "false"))
+            (os.environ.get('ADMIN_EXEMPT').lower() != "false"))
 
         if (self.debug):
             print("🔵 debug:", self.debug)


### PR DESCRIPTION
As written (by unknown idiot), there was no way to actually disable things by setting `DEBUG` and `ADMIN_EXEMPT` env vars to false (as claimed by docs), as their value was converted to uppercase and then tested for a lower case `false`. Fixed to forcing to _lowercase_ with `.lower()`.
